### PR TITLE
Fix for Linux kernel 4.0.4

### DIFF
--- a/src/cypress_ps2.c
+++ b/src/cypress_ps2.c
@@ -538,7 +538,7 @@ static void cypress_process_packet(struct psmouse *psmouse, bool zero_pkt)
 		pos[i].y = contact->y;
 	}
 
-	input_mt_assign_slots(input, slots, pos, n);
+	input_mt_assign_slots(input, slots, pos, n, 0);
 
 	for (i = 0; i < n; i++) {
 		contact = &report_data.contacts[i];


### PR DESCRIPTION
Linux 4.0.4 added a new argument, dmax, to the function input_mt_assign_slots()[(git log)](https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/drivers/input/input-mt.c?id=448c7f3830ca283e485aa943279acea6bde8b270), so I did a little work for this driver. :)
